### PR TITLE
populate values of :keywords: as tags

### DIFF
--- a/lib/eleventy-asciidoc.js
+++ b/lib/eleventy-asciidoc.js
@@ -30,8 +30,18 @@ const getData = (inputPath) => {
   const doc = asciidoctor.load(content);
   const attributes = doc.getAttributes();
   const title = doc.getDocumentTitle();
+
+  const keywordString = attributes.keywords;
+  let keywords = [];
+  if (keywordString) {
+    keywords = keywordString.split(" ");
+  }
+
+  data.tags = keywords;
+
   debug(`Document title ${title}`);
   debug(`Document attributes: ${attributes}`);
+  debug(`Document tags: ${keywordString}`);
 
   return {
     title,

--- a/tests/fixtures/with-asciidoc-attributes.adoc
+++ b/tests/fixtures/with-asciidoc-attributes.adoc
@@ -1,4 +1,5 @@
 :author: Jane Doe
 = Hello world
+:keywords: keyword1 keyword2
 
 This text is written in AsciiDoc format.

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -64,3 +64,12 @@ test("Populate data.asciidocAttributes with AsciiDoc attributes", async (t) => {
 
   t.is(result.asciidocAttributes.author, "Jane Doe");
 });
+
+test("Populate keywords as tags", async (t) => {
+  const processor = eleventyAsciidoc();
+  const result = processor.getData(
+    path.join(sourcePath, "with-asciidoc-attributes.adoc")
+  );
+
+  t.deepEqual(result.tags, ["keyword1", "keyword2"]);
+});


### PR DESCRIPTION
When using this plugin together with [eleventy-base-blog](https://github.com/11ty/eleventy-base-blog) it would be a helpful feature to populate the keywords as tags.

This is my brief suggestion. If I can do more to integrate this feature, please let me know.

Thanks for your effort and support.