### PR TITLE
Allow for permalink:false, add test for this

### DIFF
--- a/lib/eleventy-asciidoc.js
+++ b/lib/eleventy-asciidoc.js
@@ -97,8 +97,7 @@ function eleventyAsciidoctor(convertOptions = {}) {
 
     if (outdir === undefined) {
       const { page } = data ?? {};
-      const { outputPath } = page ?? {};
-      
+
       // When front matter `permalink` is `false`, `outputPath` will be `false'.
       // So, keeping that as default value.
       const { outputPath = false } = page ?? {};

--- a/lib/eleventy-asciidoc.js
+++ b/lib/eleventy-asciidoc.js
@@ -98,10 +98,12 @@ function eleventyAsciidoctor(convertOptions = {}) {
     if (outdir === undefined) {
       const { page } = data ?? {};
       const { outputPath } = page ?? {};
-      if (outputPath !== undefined) {
-        if (outputPath !== false) {
-          outdir = path.dirname(outputPath);
-        }
+      
+      // When front matter `permalink` is `false`, `outputPath` will be `false'.
+      // So, keeping that as default value.
+      const { outputPath = false } = page ?? {};
+      if (outputPath !== false) {
+        outdir = path.dirname(outputPath);
       }
     }
 

--- a/lib/eleventy-asciidoc.js
+++ b/lib/eleventy-asciidoc.js
@@ -99,7 +99,9 @@ function eleventyAsciidoctor(convertOptions = {}) {
       const { page } = data ?? {};
       const { outputPath } = page ?? {};
       if (outputPath !== undefined) {
-        outdir = path.dirname(outputPath);
+        if (outputPath !== false) {
+          outdir = path.dirname(outputPath);
+        }
       }
     }
 

--- a/tests/fixtures/front-matter/permalink-false.adoc
+++ b/tests/fixtures/front-matter/permalink-false.adoc
@@ -1,0 +1,9 @@
+---
+layout: base.njk
+permalink: false
+---
+
+= About this page
+
+This text is never written to disk because the permalink has been (deliberately)
+set to false.

--- a/tests/front-matter.js
+++ b/tests/front-matter.js
@@ -19,7 +19,7 @@ test("Page titles are populated", async (t) => {
   );
   const json = await elev.toJSON();
 
-  t.is(json.length, 2);
+  t.is(json.length, 3);
 
   const home = json.find((d) => d.inputPath.endsWith("home.adoc"));
   const homeTitle = getHtmlTitle(home.content);
@@ -40,11 +40,16 @@ test("Permalinks are mapped correctly", async (t) => {
   );
   const json = await elev.toJSON();
 
-  t.is(json.length, 2);
+  t.is(json.length, 3);
 
   const home = json.find((d) => d.inputPath.endsWith("home.adoc"));
   t.is(home.url, "/");
 
   const about = json.find((d) => d.inputPath.endsWith("about-us.adoc"));
   t.is(about.url, "/about/");
+
+  const permalinkFalse = json.find((d) =>
+    d.inputPath.endsWith("permalink-false.adoc"),
+  );
+  t.is(permalinkFalse.outputPath, false);
 });


### PR DESCRIPTION
This makes the plugin accept files with front-matter where permalink is set to false.

Setting permalink to false is useful when you create a single-page website where sections of content are put into files of their own (something like "our mission", "career" etc.) and are included in index.html (via looping in the layout for index.html), but should not be written to disks as separate files. This can be achieved with permalink:false.

Here's a reference to the 11ty docs that describe this setting: https://www.11ty.dev/docs/permalinks/.

Without the change, the permalink:false makes the plugin crash, with output like this:

[11ty] Original error stack trace: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type boolean (false)
